### PR TITLE
Fix auth container failures after Wolfi migration

### DIFF
--- a/ContainerFile/auth/Dockerfile
+++ b/ContainerFile/auth/Dockerfile
@@ -5,14 +5,18 @@ RUN apk add --no-cache \
     openldap \
     openldap-back-mdb \
     openldap-clients \
-    ca-certificates-bundle
+    ca-certificates-bundle \
+    ca-certificates
 
 # Create ldap user/group — Wolfi does NOT auto-create this
 # BusyBox syntax: addgroup/adduser (not groupadd/useradd)
 RUN addgroup -S ldap && adduser -S -D -H -G ldap ldap
 
-RUN mkdir -p /var/lib/openldap/openldap-data && \
-    chown -R ldap:ldap /var/lib/openldap
+RUN mkdir -p /var/lib/openldap/openldap-data \
+             /usr/local/share/ca-certificates \
+             /container-init && \
+    chown -R ldap:ldap /var/lib/openldap && \
+    chown ldap:ldap /var/run/openldap
 
 EXPOSE 389 636
 
@@ -24,6 +28,7 @@ CMD ["/bin/sh", "-c", "\
     chown -R ldap:ldap /var/lib/openldap && \
     touch /var/lib/openldap/openldap-data/__initialized; \
   fi; \
+  chmod 644 /etc/openldap/certs/ldapserver.key 2>/dev/null; \
   cp /etc/openldap/certs/ldapserver.crt /usr/local/share/ca-certificates/ldapserver.crt && \
   update-ca-certificates; \
   exec /usr/sbin/slapd -f /etc/openldap/slapd.conf -h 'ldap:/// ldaps:///' -u ldap -g ldap -d 0 \


### PR DESCRIPTION
The Wolfi-based OpenLDAP packages the MDB backend as a dynamic module unlike Fedora which compiled it statically. This caused the auth container to crash on startup with "Unrecognized database type (mdb)".

Additional fixes in the Dockerfile:
- Add ca-certificates package for update-ca-certificates command
- Create /usr/local/share/ca-certificates/ directory (missing in Wolfi)
- Create /container-init directory at build time
- Fix /var/run/openldap/ ownership for ldap user (pidfile writes)
- chmod TLS key file readable after mount (OpenLDAP 2.6 reads certs after dropping privileges to ldap user)