### PR TITLE
fix(dataset): add missing router field to project_default network_spec.yml

### DIFF
--- a/datasets/project_default/network_spec.yml
+++ b/datasets/project_default/network_spec.yml
@@ -24,6 +24,8 @@
 # - 'primary_oim_bmc_ip': The iDRAC  IP address of the OIM server,
 #     Mandatory only if idrac_telemetry is set to true and telemetry data needs to be collected from the OIM server.
 #     Optional — can be omitted if iDRAC telemetry for the OIM server is not required.
+# - 'router': The gateway/router IP for the admin network (used as DHCP option 3).
+#     Mandatory. If no dedicated router is available, use 'primary_oim_admin_ip'.
 # - 'dynamic_range': The range of dynamic IP addresses available on the admin network.
 # - 'dns': The list of external DNS server IP address for the admin network.
 # - 'ntp_servers': The list of NTP servers for the admin network. Each NTP server entry should include: 
@@ -69,6 +71,7 @@ Networks:
     netmask_bits: "24"
     primary_oim_admin_ip: "172.16.107.254"
     primary_oim_bmc_ip: ""
+    router: "172.16.107.254"
     dynamic_range: "172.16.107.201-172.16.107.250"
     dns: []
     ntp_servers: []


### PR DESCRIPTION
## Summary

- Add mandatory `router` field to `datasets/project_default/network_spec.yml` admin_network section
- Add `router` documentation to the file comments, consistent with `omnia/input/network_spec.yml`

## Root Cause

The mandatory `router` field was added to `admin_network` in omnia commit `d730b7dc8` which updated:
- L1 JSON schema (`network_spec.json`) — `router` added to `required` array
- `deploy_openchami.yml` — `coredhcp_router: "{{ network_data.admin_network.router }}"`
- Official input template `omnia/input/network_spec.yml`

However, the `project_default` test dataset in omnia-containers was **not updated**, causing `prepare_oim` molecule tests to fail at L1 schema validation with Ansible exit code 2.

## Changes

| File | Change |
|------|--------|
| `datasets/project_default/network_spec.yml` | Added `router: "172.16.107.254"` (matching `primary_oim_admin_ip`) and documentation comments |

## Test Plan

- [ ] `prepare_oim` molecule converge passes L1 schema validation
- [ ] `prepare_oim` molecule verify passes all sanity tests
- [ ] Network_spec.yml matches omnia/input/network_spec.yml structure

Signed-off-by: Sujit Jadhav <sujit.jadhav@dell.com>