### PR TITLE
Add TC-19: HPC benchmark staging idempotency test

### DIFF
--- a/automation_library/hpc_benchmarks/__init__.py
+++ b/automation_library/hpc_benchmarks/__init__.py
@@ -62,6 +62,7 @@ from .functions import (
     verify_geopm_aarch64_warning,
     verify_nfs_unavailable_failure,
     verify_unsupported_package_type,
+    verify_staging_idempotency,
 )
 from .vars import (
     X86_64_NODE_FUNCTIONAL_GROUP,
@@ -118,6 +119,8 @@ __all__ = [
     "verify_container_image_flow_unaffected",
     "verify_openmpi_unaffected",
     "verify_existing_hpc_dirs_preserved",
+    # Idempotency
+    "verify_staging_idempotency",
     # Regression
     # Performance
     # Negative / Error

--- a/automation_library/hpc_benchmarks/functions/__init__.py
+++ b/automation_library/hpc_benchmarks/functions/__init__.py
@@ -53,6 +53,7 @@ from .hpc_benchmarks_func import (
     verify_geopm_aarch64_warning,
     verify_nfs_unavailable_failure,
     verify_unsupported_package_type,
+    verify_staging_idempotency,
 )
 
 __all__ = [
@@ -94,4 +95,5 @@ __all__ = [
     "verify_geopm_aarch64_warning",
     "verify_nfs_unavailable_failure",
     "verify_unsupported_package_type",
+    "verify_staging_idempotency",
 ]

--- a/automation_library/hpc_benchmarks/functions/hpc_benchmarks_func.py
+++ b/automation_library/hpc_benchmarks/functions/hpc_benchmarks_func.py
@@ -2143,3 +2143,161 @@ def verify_unsupported_package_type(host) -> Dict[str, Any]:
         "details": details,
         "checked": True,
     }
+
+
+# =============================================================================
+# TC-I02: ARTIFACT STAGING IDEMPOTENCY AND RE-RUN RECOVERY
+# =============================================================================
+
+def verify_staging_idempotency(host, node_ip: str) -> Dict[str, Any]:
+    """
+    TC-I02: Run pull_benchmarks.sh twice on the same node; verify:
+      1. Directory listing under /hpc_tools/ is identical before and after re-run
+      2. No new directories created, no existing directories removed
+      3. File count inside each tool directory is unchanged
+      4. Script reports all tools as SKIPPED (already present) on second run
+
+    This confirms the staging pipeline is safe to re-run without side effects.
+
+    Args:
+        host: Testinfra host object
+        node_ip: Admin IP of the cluster node under test
+
+    Returns:
+        Dict with success, details, and error keys
+
+    Maps to: BL-005, AC-6.1.3, TC-I02
+    """
+    arch = _detect_node_arch(host, node_ip)
+    expected_packages = _get_benchmark_packages_for_arch(arch)
+
+    # ── Step 1: Record pre-state ─────────────────────────────────────────
+    pre_ls = _ssh(host, node_ip, f"ls {HPC_TOOLS_BASE}/")
+    if pre_ls.rc != 0:
+        return {
+            "success": False,
+            "error": (
+                f"{HPC_TOOLS_BASE}/ not accessible on {node_ip} "
+                f"(rc={pre_ls.rc}): {pre_ls.stderr.strip()}"
+            ),
+            "details": None,
+        }
+
+    pre_dirs = sorted(d.strip() for d in pre_ls.stdout.splitlines() if d.strip())
+
+    # Record file counts inside each benchmark tool directory
+    pre_file_counts = {}
+    for pkg in expected_packages:
+        tool_dir = TOOL_TO_DIR.get(pkg, pkg)
+        count_cmd = _ssh(
+            host, node_ip,
+            f"ls -1 {HPC_TOOLS_BASE}/{tool_dir}/ 2>/dev/null | wc -l"
+        )
+        pre_file_counts[tool_dir] = (
+            int(count_cmd.stdout.strip()) if count_cmd.rc == 0 else 0
+        )
+
+    # ── Step 2: Re-run pull_benchmarks.sh ────────────────────────────────
+    pull_result = _ssh(host, node_ip, f"bash {PULL_BENCHMARKS_SCRIPT} 2>&1")
+    if pull_result.rc != 0:
+        return {
+            "success": False,
+            "error": (
+                f"pull_benchmarks.sh failed on re-run (rc={pull_result.rc}): "
+                f"{pull_result.stdout.strip()[-300:]}"
+            ),
+            "details": None,
+        }
+
+    # Small settle delay for NFS propagation
+    time.sleep(3)
+
+    # ── Step 3: Record post-state ────────────────────────────────────────
+    post_ls = _ssh(host, node_ip, f"ls {HPC_TOOLS_BASE}/")
+    post_dirs = sorted(d.strip() for d in post_ls.stdout.splitlines() if d.strip())
+
+    post_file_counts = {}
+    for pkg in expected_packages:
+        tool_dir = TOOL_TO_DIR.get(pkg, pkg)
+        count_cmd = _ssh(
+            host, node_ip,
+            f"ls -1 {HPC_TOOLS_BASE}/{tool_dir}/ 2>/dev/null | wc -l"
+        )
+        post_file_counts[tool_dir] = (
+            int(count_cmd.stdout.strip()) if count_cmd.rc == 0 else 0
+        )
+
+    # ── Step 4: Compare ──────────────────────────────────────────────────
+    errors = []
+
+    # 4a. Directory listing must be identical
+    added_dirs = sorted(set(post_dirs) - set(pre_dirs))
+    removed_dirs = sorted(set(pre_dirs) - set(post_dirs))
+
+    if added_dirs:
+        errors.append(f"New directories created after re-run: {added_dirs}")
+    if removed_dirs:
+        errors.append(f"Directories removed after re-run: {removed_dirs}")
+
+    # 4b. File counts inside each tool directory must be unchanged
+    count_diffs = []
+    for tool_dir in pre_file_counts:
+        pre_count = pre_file_counts[tool_dir]
+        post_count = post_file_counts.get(tool_dir, 0)
+        if pre_count != post_count:
+            count_diffs.append(
+                f"{tool_dir}: {pre_count} -> {post_count}"
+            )
+
+    if count_diffs:
+        errors.append(f"File count changes after re-run: {count_diffs}")
+
+    # 4c. Script output should show all tools as SKIPPED (already present)
+    output = pull_result.stdout
+    lines = output.splitlines()
+    downloaded_on_rerun = []
+
+    for pkg in expected_packages:
+        tool_dir = TOOL_TO_DIR.get(pkg, pkg)
+        names = {pkg.lower(), tool_dir.lower()}
+        tool_lines = [
+            line for line in lines
+            if any(n in line.lower() for n in names)
+        ]
+        tool_text = " ".join(tool_lines).lower()
+        if "[success]" in tool_text or "staged at" in tool_text:
+            downloaded_on_rerun.append(pkg)
+
+    if downloaded_on_rerun:
+        errors.append(
+            f"Tools re-downloaded instead of skipped on second run: "
+            f"{downloaded_on_rerun}"
+        )
+
+    # ── Result ───────────────────────────────────────────────────────────
+    if errors:
+        return {
+            "success": False,
+            "error": "; ".join(errors),
+            "details": (
+                f"Pre-run dirs ({len(pre_dirs)}): {pre_dirs}\n"
+                f"Post-run dirs ({len(post_dirs)}): {post_dirs}\n"
+                f"Pre file counts: {pre_file_counts}\n"
+                f"Post file counts: {post_file_counts}\n"
+                f"Script output (last 300 chars):\n"
+                f"{output.strip()[-300:]}"
+            ),
+        }
+
+    details_lines = [
+        f"Staging idempotency verified on {node_ip} (arch={arch}):",
+        f"  Directory listing identical: {len(pre_dirs)} dirs before and after",
+        f"  File counts unchanged: {pre_file_counts}",
+        f"  All {len(expected_packages)} tools reported SKIPPED on re-run",
+        f"  No tools re-downloaded",
+    ]
+    return {
+        "success": True,
+        "error": None,
+        "details": "\n".join(details_lines),
+    }

--- a/automation_library/hpc_benchmarks/messages/hpc_benchmarks_msgs.py
+++ b/automation_library/hpc_benchmarks/messages/hpc_benchmarks_msgs.py
@@ -154,6 +154,11 @@ TEST_LOG_MSGS: Dict[str, str] = {
     "idempotency_changes_found": "Second run showed changes — idempotency FAILED",
     "dirs_identical":           "hpc_tools/ directory structure identical after both runs",
     "dirs_differ":              "hpc_tools/ directory structure differs after re-run",
+    "idempotency_pre_state":    "Recorded pre-run state: {count} dirs under hpc_tools/",
+    "idempotency_rerun":        "Re-running pull_benchmarks.sh on {ip}",
+    "idempotency_post_state":   "Recorded post-run state: {count} dirs under hpc_tools/",
+    "idempotency_all_skipped":  "All {count} tools reported SKIPPED on re-run — idempotency confirmed",
+    "idempotency_redownloaded": "Tools re-downloaded on second run (expected SKIPPED): {tools}",
 
     # OS compatibility
     "rhel_version_ok":          "Node {ip} is RHEL {version} — compatible",
@@ -421,5 +426,16 @@ TEST_ASSERT_MSGS: Dict[str, str] = {
         "Unsupported package type was not rejected before staging.\n"
         "Expected: Validation error with specific message; other tools unaffected.\n"
         "Ref: FSpec §5.1.5, TC-E06"
+    ),
+    "staging_idempotency_failed": (
+        "Staging is not idempotent — re-running pull_benchmarks.sh altered hpc_tools/.\n"
+        "Expected: Same directory listing, same file counts, all tools SKIPPED.\n"
+        "Actual: {details}\n"
+        "\n"
+        "HOW TO FIX:\n"
+        "  1. Check pull_benchmarks.sh skip logic for 'already present' detection\n"
+        "  2. Verify hpc_tools.yml does not unconditionally overwrite existing dirs\n"
+        "  3. Re-run: bash /hpc_tools/scripts/pull_benchmarks.sh 2>&1 | grep -i skip\n"
+        "Ref: BL-005, AC-6.1.3, TC-I02"
     ),
 }

--- a/molecule/hpc_benchmarks/tests/sanity/test_hpc_benchmarks_functional.py
+++ b/molecule/hpc_benchmarks/tests/sanity/test_hpc_benchmarks_functional.py
@@ -35,6 +35,7 @@ Test IDs:
   TC-16  test_container_image_flow_unaffected
   TC-17  test_openmpi_unaffected
   TC-18  test_existing_hpc_dirs_preserved
+  TC-19  test_staging_idempotency
 
 Spec: TSPEC-HPCBENCH-2026-001 v1.0.0
 """
@@ -64,6 +65,7 @@ from automation_library.hpc_benchmarks import (
     verify_container_image_flow_unaffected,
     verify_openmpi_unaffected,
     verify_existing_hpc_dirs_preserved,
+    verify_staging_idempotency,
 )
 
 
@@ -561,6 +563,40 @@ def test_existing_hpc_dirs_preserved(host, cluster_node_ip):
         log.failed(result["error"])
         assert result["success"], TEST_ASSERT_MSGS["existing_dirs_modified"].format(
             dir=result.get("error", "")
+        )
+
+
+# =============================================================================
+# TC-19: ARTIFACT STAGING IDEMPOTENCY
+# =============================================================================
+
+@pytest.mark.sanity
+@pytest.mark.idempotency
+@pytest.mark.order(19)
+def test_staging_idempotency(host, cluster_node_ip):
+    """
+    TC-19: Re-run pull_benchmarks.sh on an already-staged cluster node;
+    verify /hpc_tools/ directory listing is identical before and after,
+    file counts inside each tool directory are unchanged, and the script
+    reports all tools as SKIPPED (already present).
+
+    This confirms the staging pipeline is safe to re-run without duplicating
+    directories, overwriting files, or causing side effects on shared NFS.
+
+    Automatically detects node architecture and checks appropriate packages.
+
+    Acceptance criteria: BL-005, AC-6.1.3
+    """
+    log = TestLogger(TEST_NAMES["artifact_staging_idempotency"])
+
+    result = verify_staging_idempotency(host, cluster_node_ip)
+
+    if result["success"]:
+        log.passed(result["details"])
+    else:
+        log.failed(result["error"])
+        assert result["success"], TEST_ASSERT_MSGS["staging_idempotency_failed"].format(
+            details=result.get("error", "")
         )
 
 


### PR DESCRIPTION
## Summary

Adds new test case **TC-19** (`test_staging_idempotency`) that verifies
re-running `pull_benchmarks.sh` on an already-staged cluster node
produces no side effects.

## What this test verifies

After initial HPC benchmark staging, if an operator re-runs `pull_benchmarks.sh`:

1. `/hpc_tools/` directory listing is **identical** before and after re-run
2. **No new directories** created, no existing directories removed
3. **File count** inside each tool directory is unchanged
4. Script reports all tools as **SKIPPED** (already present)

## Changes (5 files)

| File | Change |
|------|--------|
| `hpc_benchmarks_func.py` | Added `verify_staging_idempotency()` |
| `functions/__init__.py` | Export new function |
| `hpc_benchmarks/__init__.py` | Export new function |
| `hpc_benchmarks_msgs.py` | Added log + assertion messages |
| `test_hpc_benchmarks_functional.py` | Added TC-19 test |

## How to run

```bash
pytest -m idempotency molecule/hpc_benchmarks/tests/sanity/ -v