### PR TITLE
Fix omnia_sh_tag_url to use _omnia_branch instead of _core_tag in URL path

### DIFF
--- a/automation_library/omnia_sh/vars/omnia_sh_vars.py
+++ b/automation_library/omnia_sh/vars/omnia_sh_vars.py
@@ -76,7 +76,7 @@ OMNIA_SH_VARS: Dict[str, Any] = {
     "omnia_clone_path": _omnia_clone_path,
     # Download URLs for omnia.sh (omnia repo, not omnia-artifactory)
     "omnia_sh_branch_url": f"{_GIT_RAW_BASE}/refs/heads/{_omnia_branch}/omnia.sh" if _omnia_branch else "",
-    "omnia_sh_tag_url": f"{_GIT_RAW_BASE}/refs/tags/{_core_tag}/omnia.sh" if _core_tag else "",
+    "omnia_sh_tag_url": f"{_GIT_RAW_BASE}/refs/tags/{_omnia_branch}/omnia.sh" if _core_tag else "",
     "omnia_sh_path": f"{_omnia_clone_path}/omnia.sh" if _omnia_clone_path else "",
     # Timeout and polling intervals for install/uninstall operations
     "install_timeout": 600,       # 10 minutes for install


### PR DESCRIPTION
## Bug Fix

**File:** `automation_library/omnia_sh/vars/omnia_sh_vars.py` (line 79)

### Problem

The `omnia_sh_tag_url` was using `_core_tag` for both the URL path segment
and the guard condition. This caused the tag-based download URL to resolve
to the wrong Git ref when `_core_tag` and `_omnia_branch` differ.

### Change

```diff
- "omnia_sh_tag_url": f"{_GIT_RAW_BASE}/refs/tags/{_core_tag}/omnia.sh" if _core_tag else "",
+ "omnia_sh_tag_url": f"{_GIT_RAW_BASE}/refs/tags/{_omnia_branch}/omnia.sh" if _core_tag else "",